### PR TITLE
Fix the server close NullReferenceException

### DIFF
--- a/GSync/src/main/java/gsync/Listener.java
+++ b/GSync/src/main/java/gsync/Listener.java
@@ -78,8 +78,12 @@ public class Listener {
 	
     public void stop() {
         try {
-            serverSocket.close();
-            listenerThread.join();
+            if (serverSocket != null) {
+                serverSocket.close();
+            }
+            if (listenerThread != null) {
+                listenerThread.join();
+            }
         } catch (IOException | InterruptedException e) {
             logger.loglnError(e.getMessage());
         }


### PR DESCRIPTION
I managed to put the server socket in wrong condition - I think this was after non-clean exit of the listener.

![ss](https://github.com/user-attachments/assets/26722f8f-c96c-4edb-9d86-356e4d4c8bbf)

This is pretty annoying, since Ghidra refuses to exit (exception is raised when trying to close the window).

I did the same for listenerThread out of abundance of caution, I'm not sure if it's actually necessary.

This may be considered a hacky solution, because I didn't (try to) understand the root cause, just fixed the place where exception occured.